### PR TITLE
Packaging fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
-## Current
+## Current (in progress)
+
+- Fix packaging 
+
+## 1.0.0 (2017-10-20)
 
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Fix packaging 
+- Fix packaging [#2](https://github.com/opendatateam/udata-ckan/pull/2)
 
 ## 1.0.0 (2017-10-20)
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 import io
 import re
@@ -125,7 +124,7 @@ setup(
     },
     license='AGPL',
     zip_safe=False,
-    keywords='udata, harvester, CKAN',
+    keywords='udata harvester CKAN',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python',


### PR DESCRIPTION
This PR fixes the packaging:
- proper changelog formatting so Bumpr can update it
- proper `setup.py` keywords so [PyPI](https://pypi.python.org/pypi/udata-ckan) can display them