### PR TITLE
Register ckan: prefixed extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Test against a real CKAN instance [#23](https://github.com/opendatateam/udata-ckan/pull/23)
 - Allows to filter on Organizations and Tags [#26](https://github.com/opendatateam/udata-ckan/pull/26)
+- Register `ckan:` prefixed extras [#28](https://github.com/opendatateam/udata-ckan/pull/28)
 
 ## 1.0.1 (2018-03-13)
 

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,10 @@ setup(
     entry_points={
         'udata.harvesters': [
             'ckan = udata_ckan.harvesters:CkanBackend',
-        ]
+        ],
+        'udata.models': [
+            'ckan = udata_ckan.models',
+        ],
     },
     license='AGPL',
     zip_safe=False,

--- a/udata_ckan/models.py
+++ b/udata_ckan/models.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from udata.models import db, Dataset
+
+Dataset.extras.register('ckan:name', db.StringField)


### PR DESCRIPTION
This PR register `ckan:` prefixed extras for proper extras validation.

Connects to opendatateam/udata#1699