### PR TITLE
Handle non valid URLs in CKAN url field (fix #29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Only store `url` field in `remote_url` extra if this is an URL otherwise store it in `ckan:source` [#30](https://github.com/opendatateam/udata-ckan/pull/30)
 
 ## 1.1.0 (2018-06-06)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,9 @@ import requests
 
 from urlparse import urljoin
 
+from faker.providers import BaseProvider
+from udata.utils import faker_provider, faker
+
 RE_API_KEY = re.compile(r'apikey=(?P<apikey>[a-f0-9-]+)\s')
 CKAN_URL = 'http://localhost:5000'
 PASTER_URL = 'http://localhost:8000'
@@ -93,3 +96,9 @@ def ckan_factory(paster):
         apikey = match.group('apikey')
         return CkanClient(apikey)
     return ckan
+
+
+@faker_provider
+class UdataCkanProvider(BaseProvider):
+    def unique_url(self):
+        return '{0}?_={1}'.format(faker.uri(), faker.unique_string())

--- a/tests/test_ckan_backend_filters.py
+++ b/tests/test_ckan_backend_filters.py
@@ -23,10 +23,10 @@ def ckan(ckan_factory):
 
 def package_factory(ckan, **kwargs):
     data = {
-        'name': faker.slug(),
+        'name': faker.unique_string(),
         'title': faker.sentence(),
         'notes': faker.paragraph(),
-        'resources': [{'url': faker.uri()}],
+        'resources': [{'url': faker.unique_url()}],
     }
     data.update(kwargs)
     response = ckan.action('package_create', data)

--- a/udata_ckan/models.py
+++ b/udata_ckan/models.py
@@ -4,3 +4,4 @@ from __future__ import unicode_literals
 from udata.models import db, Dataset
 
 Dataset.extras.register('ckan:name', db.StringField)
+Dataset.extras.register('ckan:source', db.StringField)


### PR DESCRIPTION
This PR is a proposal fix for #29 

The `url` field is stored in `remote_url` only if it's a valid URL otherwise it's stored in `ckan:source`.

To avoid dataset and resource collision on CKAN side, this PR ensures slug and resources URL are unique during tests.