### PR TITLE
Improve extras parsing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,9 @@ jobs:
           command: export BASE_BRANCH=$(base_branch)
       - restore_cache:
           keys:
-          - py-cache-v4-{{ arch }}-{{ checksum "python.deps" }}
-          - py-cache-v4-{{ arch }}-{{ .Branch }}
-          - py-cache-v4-{{ arch }}-{{ .Environment.BASE_BRANCH }}
+          - py-cache-v5-{{ arch }}-{{ checksum "python.deps" }}
+          - py-cache-v5-{{ arch }}-{{ .Branch }}
+          - py-cache-v5-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
           command: |
@@ -52,11 +52,11 @@ jobs:
             source venv/bin/activate
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:
-          key: py-cache-v4-{{ arch }}-{{ checksum "python.deps" }}
+          key: py-cache-v5-{{ arch }}-{{ checksum "python.deps" }}
           paths:
           - venv
       - save_cache:
-          key: py-cache-v4-{{ arch }}-{{ .Branch }}
+          key: py-cache-v5-{{ arch }}-{{ .Branch }}
           paths:
           - venv
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Only store `url` field in `remote_url` extra if this is an URL otherwise store it in `ckan:source` [#30](https://github.com/opendatateam/udata-ckan/pull/30)
 - Properly handle geometry errors [#31](https://github.com/opendatateam/udata-ckan/pull/31)
+- Improve extras parsing [#32](https://github.com/opendatateam/udata-ckan/pull/32):
+  - Skip empty extras
+  - Parse update frequencies as RDF URI or udata frequency identifier
+  - Parse `spatial-text` matching a known zone name or slug
+  - Store unknown `spatial-uri`, `spatial-text` and `frequency` as `ckan:spatial-uri`, `ckan:spatial-text` and `ckan:frequency`
 
 ## 1.1.0 (2018-06-06)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,1 +1,1 @@
-udata>=1.4.0
+udata>=1.4.1.dev

--- a/tests/test_ckan_backend.py
+++ b/tests/test_ckan_backend.py
@@ -374,6 +374,7 @@ def test_minimal_metadata(data, result, kwargs):
 @pytest.mark.ckan_data('all_metadata')
 def test_all_metadata(data, result):
     resource_data = data['resources'][0]
+    resource_result = result['result']['resources'][0]
 
     dataset = dataset_for(result)
     assert dataset.title == data['title']
@@ -388,7 +389,8 @@ def test_all_metadata(data, result):
     assert resource.title == resource_data['name']
     assert resource.description == resource_data['description']
     assert resource.url == resource_data['url']
-    assert resource.format == resource_data['format']
+    # Use result because format is normalized by CKAN
+    assert resource.format == resource_result['format'].lower()
     assert resource.mime == resource_data['mimetype']
 
 

--- a/udata_ckan/harvesters.py
+++ b/udata_ckan/harvesters.py
@@ -205,7 +205,11 @@ class CkanBackend(BaseBackend):
             # GeoJSON representation (Polygon or Point)
             key = extra['key']
             value = extra['value']
-            if key == 'spatial':
+            if value is None or (
+                isinstance(value, basestring) and not value.strip()
+            ):
+                continue
+            elif key == 'spatial':
                 spatial_geom = json.loads(value)
             #  Textual representation of the extent / location
             elif key == 'spatial-text':

--- a/udata_ckan/harvesters.py
+++ b/udata_ckan/harvesters.py
@@ -204,28 +204,21 @@ class CkanBackend(BaseBackend):
                 spatial_geom = json.loads(extra['value'])
             #  Textual representation of the extent / location
             elif extra['key'] == 'spatial-text':
-                log.debug('spatial-text value not handled')
-                print 'spatial-text', extra['value']
+                log.debug('spatial-text value not handled: %s', extra['value'])
             # Linked Data URI representing the place name
             elif extra['key'] == 'spatial-uri':
-                log.debug('spatial-uri value not handled')
-                print 'spatial-uri', extra['value']
+                log.debug('spatial-uri value not handled: %s', extra['value'])
             # Update frequency
             elif extra['key'] == 'frequency':
-                print 'frequency', extra['value']
+                log.debug('frequency value not handled: %s', extra['value'])
             # Temporal coverage start
             elif extra['key'] == 'temporal_start':
-                print 'temporal_start', extra['value']
                 temporal_start = daterange_start(extra['value'])
-                continue
             # Temporal coverage end
             elif extra['key'] == 'temporal_end':
-                print 'temporal_end', extra['value']
                 temporal_end = daterange_end(extra['value'])
-                continue
-            # else:
-            #     print extra['key'], extra['value']
-            dataset.extras[extra['key']] = extra['value']
+            else:
+                dataset.extras[extra['key']] = extra['value']
 
         if spatial_geom:
             dataset.spatial = SpatialCoverage()


### PR DESCRIPTION
This PR improve extras parsing:
- Skip empty extras
- Parse update frequencies (`frequency`à as RDF URI or udata frequency identifier
- Parse `spatial-text` matching a known zone name or slug
- Store unknown `spatial-uri`, `spatial-text` and `frequency` as `ckan:spatial-uri`, `ckan:spatial-text` and `ckan:frequency`