### PR TITLE
Improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Support both inclusion and exclusion filters [#42](https://github.com/opendatateam/udata-ckan/pull/42)
 - Localization support [#43](https://github.com/opendatateam/udata-ckan/pull/43)
 - Test the minimum accepted CKAN dataset payload and make the `extras` property optional [#57](https://github.com/opendatateam/udata-ckan/pull/57)
+- Improved error handling (support details in JSON responses, also handle raw quoted strings and HTML) [#56](https://github.com/opendatateam/udata-ckan/pull/56)
 
 ## 1.1.1 (2018-06-15)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,9 @@ testpaths = tests
 python_files = test_*.py
 python_functions = test_*
 python_classes = *Test
+# See: https://docs.pytest.org/en/latest/warnings.html#deprecationwarning-and-pendingdeprecationwarning
+filterwarnings =
+    ignore::DeprecationWarning:mongoengine
 
 [pycodestyle]
 max-line-length = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,8 @@ from udata.utils import faker_provider, faker
 RE_API_KEY = re.compile(r'apikey=(?P<apikey>[a-f0-9-]+)\s')
 CKAN_URL = 'http://localhost:5000'
 PASTER_URL = 'http://localhost:8000'
+CKAN_WAIT_TIMEOUT = 120  # Max time to wait for CKAN being ready (in seconds)
+PASTER_TIMEOUT = 100  # Max time to wait for paster API calls (in seconds)
 
 
 class CkanError(ValueError):
@@ -63,7 +65,7 @@ class PasterClient(object):
     URL = PASTER_URL
 
     def __call__(self, cmd):
-        response = requests.post(self.URL, data=cmd, timeout=100)
+        response = requests.post(self.URL, data=cmd, timeout=PASTER_TIMEOUT)
         if response.status_code != 200:
             raise PasterError(response.text.strip())
         return response.text
@@ -74,7 +76,7 @@ def wait_for_ckan():
     print('waiting for CKAN')
     while True:
         try:
-            requests.get(CKAN_URL, timeout=5)
+            requests.get(CKAN_URL, timeout=CKAN_WAIT_TIMEOUT)
             print('CKAN is ready')
             return
         except requests.exceptions.Timeout:

--- a/tests/test_ckan_backend.py
+++ b/tests/test_ckan_backend.py
@@ -540,7 +540,7 @@ def test_minimal_ckan_response(rmock):
         }
     }
     source = HarvestSourceFactory(backend='ckan', url=CKAN_URL)
-    rmock.get(PACKAGE_LIST_URL, json={'result': [name]}, status_code=200,
+    rmock.get(PACKAGE_LIST_URL, json={'success': True, 'result': [name]}, status_code=200,
               headers={'Content-Type': 'application/json'})
     rmock.get(PACKAGE_SHOW_URL, json=json, status_code=200,
               headers={'Content-Type': 'application/json'})

--- a/tests/test_ckan_backend_errors.py
+++ b/tests/test_ckan_backend_errors.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from udata.harvest import actions
+from udata.harvest.tests.factories import HarvestSourceFactory
+
+
+pytestmark = [
+    pytest.mark.usefixtures('clean_db'),
+    pytest.mark.options(PLUGINS=['ckan']),
+]
+
+CKAN_URL = 'https://harvest.me/'
+API_URL = '{}api/3/action/package_list'.format(CKAN_URL)
+
+# We test against success and error status code
+# because CKAN API always return 200
+# but some other cases may happen outside the API
+STATUS_CODE = (200, 400, 500)
+
+
+@pytest.mark.parametrize('code', STATUS_CODE)
+def test_html_error(rmock, code):
+    # Happens with wrong source URL (html is returned instead of json)
+    html = '<html><body>Error</body></html>'
+    source = HarvestSourceFactory(backend='ckan', url=CKAN_URL)
+
+    rmock.get(API_URL, text=html, status_code=code,
+              headers={'Content-Type': 'text/html'})
+
+    actions.run(source.slug)
+
+    source.reload()
+
+    job = source.get_last_job()
+    assert len(job.items) is 0
+    assert len(job.errors) is 1
+    error = job.errors[0]
+    # HTML is detected and does not clutter the message
+    assert html not in error.message
+
+
+@pytest.mark.parametrize('code', STATUS_CODE)
+def test_plain_text_error(rmock, code):
+    source = HarvestSourceFactory(backend='ckan', url=CKAN_URL)
+
+    rmock.get(API_URL, text='"Some error"', status_code=code,
+              headers={'Content-Type': 'text/plain'})
+
+    actions.run(source.slug)
+
+    source.reload()
+
+    job = source.get_last_job()
+    assert len(job.items) is 0
+    assert len(job.errors) is 1
+    error = job.errors[0]
+    # Raw quoted string is properly unquoted
+    assert error.message == 'Some error'
+
+
+def test_standard_api_json_error(rmock):
+    json = {'success': False, 'error': 'an error'}
+    source = HarvestSourceFactory(backend='ckan', url=CKAN_URL)
+
+    rmock.get(API_URL, json=json, status_code=200,
+              headers={'Content-Type': 'application/json'})
+
+    actions.run(source.slug)
+
+    source.reload()
+
+    job = source.get_last_job()
+    assert len(job.items) is 0
+    assert len(job.errors) is 1
+    error = job.errors[0]
+    assert error.message == 'an error'
+
+
+def test_standard_api_json_error_with_details(rmock):
+    json = {'success': False, 'error': {
+        'message': 'an error',
+    }}
+    source = HarvestSourceFactory(backend='ckan', url=CKAN_URL)
+
+    rmock.get(API_URL, json=json, status_code=200,
+              headers={'Content-Type': 'application/json'})
+
+    actions.run(source.slug)
+
+    source.reload()
+
+    job = source.get_last_job()
+    assert len(job.items) is 0
+    assert len(job.errors) is 1
+    error = job.errors[0]
+    assert error.message == 'an error'
+
+
+def test_standard_api_json_error_with_details_and_type(rmock):
+    json = {'success': False, 'error': {
+        'message': 'Access denied',
+        '__type': 'Authorization Error',
+    }}
+    source = HarvestSourceFactory(backend='ckan', url=CKAN_URL)
+
+    rmock.get(API_URL, json=json, status_code=200,
+              headers={'Content-Type': 'application/json'})
+
+    actions.run(source.slug)
+
+    source.reload()
+
+    job = source.get_last_job()
+    assert len(job.items) is 0
+    assert len(job.errors) is 1
+    error = job.errors[0]
+    assert error.message == 'Authorization Error: Access denied'

--- a/udata_ckan/harvesters.py
+++ b/udata_ckan/harvesters.py
@@ -160,7 +160,7 @@ class CkanBackend(BaseBackend):
         elif mime_type == 'text/html':  # Standard html error page
             raise HarvestException('Unknown Error: {} returned HTML'.format(url))
         else:
-            # If it's not HTML, CKAN response with raw quoted test
+            # If it's not HTML, CKAN respond with raw quoted text
             msg = response.text.strip('"')
             raise HarvestException(msg)
 

--- a/udata_ckan/harvesters.py
+++ b/udata_ckan/harvesters.py
@@ -134,10 +134,35 @@ class CkanBackend(BaseBackend):
             response = self.post(url, '{}', params=kwargs)
         else:
             response = self.get(url, params=kwargs)
-        if response.status_code != 200:
+
+        content_type = response.headers.get('Content-Type', '')
+        mime_type = content_type.split(';', 1)[0]
+
+        if mime_type == 'application/json':  # Standard API JSON response
+            data = response.json()
+            # CKAN API always returns 200 even on errors
+            # Only the `success` property allows to detect errors
+            if data.get('success', False):
+                return data
+            else:
+                error = data.get('error')
+                if isinstance(error, dict):
+                    # Error object with message
+                    msg = error.get('message', 'Unknown error')
+                    if '__type' in error:
+                        # Typed error
+                        msg = ': '.join((error['__type'], msg))
+                else:
+                    # Error only contains a message
+                    msg = error
+                raise HarvestException(msg)
+
+        elif mime_type == 'text/html':  # Standard html error page
+            raise HarvestException('Unknown Error: {} returned HTML'.format(url))
+        else:
+            # If it's not HTML, CKAN response with raw quoted test
             msg = response.text.strip('"')
             raise HarvestException(msg)
-        return response.json()
 
     def get_status(self):
         url = urljoin(self.source.url, '/api/util/status')


### PR DESCRIPTION
This PR improve CKAN Harvester error handling:
- Properly handle both flat and nested JSON errors and optionnaly `__type` property
- Avoid cluterring error message when response is HTML (404, bad URL, proxy errors...)
- Properly handle raw quoted strings (which CKAN sometimes send)

This will improve harvest reports readability and massively reduce harvest jobs history (HTML pages were entirely stored for each HTML error)