### PR TITLE
Ensure the CKAN Harvester works with the minimum dataset payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Support both inclusion and exclusion filters [#42](https://github.com/opendatateam/udata-ckan/pull/42)
 - Localization support [#43](https://github.com/opendatateam/udata-ckan/pull/43)
+- Test the minimum accepted CKAN dataset payload and make the `extras` property optional [#57](https://github.com/opendatateam/udata-ckan/pull/57)
 
 ## 1.1.1 (2018-06-15)
 

--- a/udata_ckan/harvesters.py
+++ b/udata_ckan/harvesters.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from urlparse import urljoin
 
 from voluptuous import (
-    Schema, All, Any, Lower, Coerce, DefaultTo
+    Schema, All, Any, Lower, Coerce, DefaultTo, Optional
 )
 
 from udata import uris
@@ -91,7 +91,7 @@ schema = Schema({
     'organization': Any(organization, None),
     'resources': [resource],
     'revision_id': basestring,
-    'extras': [{
+    Optional('extras', default=list): [{
         'key': basestring,
         'value': Any(basestring, int, float, boolean, dict, list),
     }],


### PR DESCRIPTION
This PR test the minimum CKAN dataset payload to ensure resilience.

`extras` property is now optionnal as some instance don't always send it.