### PR TITLE
Fix filetype (always remote)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix filetype (always remote) [#98](https://github.com/opendatateam/udata-ckan/pull/98)
 
 ## 1.2.0 (2018-10-02)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,1 +1,2 @@
 udata>=1.6.0
+requests==2.21.0

--- a/udata_ckan/harvesters.py
+++ b/udata_ckan/harvesters.py
@@ -323,8 +323,7 @@ class CkanBackend(BaseBackend):
             resource.title = res.get('name', '') or ''
             resource.description = res.get('description')
             resource.url = res['url']
-            resource.filetype = ('api' if res['resource_type'] == 'api'
-                                 else 'remote')
+            resource.filetype = 'remote'
             resource.format = res.get('format')
             resource.mime = res.get('mimetype')
             resource.hash = res.get('hash')


### PR DESCRIPTION
We do not support the `api` value for `resource.filetype` anymore.