### PR TITLE
Max out package_search rows limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Max out package_search rows limit [#100](https://github.com/opendatateam/udata-ckan/pull/98)
 
 ## 1.2.1 (2019-05-24)
 

--- a/udata_ckan/harvesters.py
+++ b/udata_ckan/harvesters.py
@@ -185,7 +185,9 @@ class CkanBackend(BaseBackend):
                     param = '-' + param
                 params.append(param)
             q = ' AND '.join(params)
-            response = self.get_action('package_search', fix=fix, q=q)
+            # max out rows count to 1000 as per
+            # https://docs.ckan.org/en/latest/api/#ckan.logic.action.get.package_search
+            response = self.get_action('package_search', fix=fix, q=q, rows=1000)
             names = [r['name'] for r in response['result']['results']]
         else:
             response = self.get_action('package_list', fix=fix)


### PR DESCRIPTION
Otherwise it defaults to `10`.