### PR TITLE
revision_id and revision_timestamp as optional fields

### DIFF
--- a/udata_ckan/schemas/ckan.py
+++ b/udata_ckan/schemas/ckan.py
@@ -43,11 +43,11 @@ organization = {
     'created': All(str, to_date),
     'title': str,
     'name': All(str, slug),
-    'revision_timestamp': All(str, to_date),
+    Optional('revision_timestamp'): All(str, to_date),
     'is_organization': boolean,
     'state': str,
     'image_url': str,
-    'revision_id': str,
+    Optional('revision_id'): str,
     'type': 'organization',
     'approval_status': 'approved'
 }

--- a/udata_ckan/schemas/ckan.py
+++ b/udata_ckan/schemas/ckan.py
@@ -65,7 +65,7 @@ schema = Schema({
     'metadata_modified': All(str, to_date),
     'organization': Any(organization, None),
     'resources': [resource],
-    'revision_id': str,
+    Optional('revision_id'): str,
     Optional('extras', default=list): [{
         'key': str,
         'value': Any(str, int, float, boolean, dict, list),


### PR DESCRIPTION
revision_id and revision_timestamp are not included in CKAN 2.9.5