### PR TITLE
Make revision id optional to match latest CKAN versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Replace mongo legacy image in CI [#219](https://github.com/opendatateam/udata-ckan/pull/219)
+- Make revision_id optional to match latest CKAN versions [#220](https://github.com/opendatateam/udata-ckan/pull/220)
 
 ## 2.0.0 (2020-03-11)
 

--- a/tests/test_ckan_backend.py
+++ b/tests/test_ckan_backend.py
@@ -533,10 +533,9 @@ def test_minimal_ckan_response(rmock):
             'notes': faker.paragraph(),
             'license_title': None,
             'state': None,
-            'revision_id': faker.unique_string(),
             'type': 'dataset',
             'resources': [],
-            # extras is not always present so we exclude it from the minimal payload
+            # extras and revision_id are not always present so we exclude them from the minimal payload
         }
     }
     source = HarvestSourceFactory(backend='ckan', url=CKAN_URL)

--- a/udata_ckan/schemas/ckan.py
+++ b/udata_ckan/schemas/ckan.py
@@ -65,7 +65,7 @@ schema = Schema({
     'metadata_modified': All(str, to_date),
     'organization': Any(organization, None),
     'resources': [resource],
-    'revision_id': str,
+    Optional('revision_id'): str,
     Optional('extras', default=list): [{
         'key': str,
         'value': Any(str, int, float, boolean, dict, list),


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/893.