### PR TITLE
item.remote_id = id ASAP

### DIFF
--- a/tests/test_ckan_backend_errors.py
+++ b/tests/test_ckan_backend_errors.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 from udata.harvest import actions

--- a/tests/test_dkan_backend.py
+++ b/tests/test_dkan_backend.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import json
 import pytest
 import os

--- a/udata_ckan/harvesters.py
+++ b/udata_ckan/harvesters.py
@@ -123,13 +123,14 @@ class CkanBackend(BaseBackend):
 
     def process(self, item):
         response = self.get_action('package_show', id=item.remote_id)
-        data = self.validate(response['result'], self.schema)
-
-        if type(data) == list:
-            data = data[0]
-
-        # Fix the remote_id: use real ID instead of not stable name
-        item.remote_id = data['id']
+        result = response["result"]
+        # DKAN
+        if type(result) == list:
+            result = result[0]
+        # fix the remote_id (id instead of name) ASAP for better error reporting
+        if result.get("id"):
+            item.remote_id = result["id"]
+        data = self.validate(result, self.schema)
 
         # Skip if no resource
         if not len(data.get('resources', [])):

--- a/udata_ckan/schemas/dkan.py
+++ b/udata_ckan/schemas/dkan.py
@@ -69,7 +69,7 @@ group = {
     'name': All(str, slug),
 }
 
-schema = Schema([{
+schema = Schema({
     'id': str,
     'name': str,
     'title': str,
@@ -92,4 +92,4 @@ schema = Schema([{
     'maintainer': Any(str, None),
     'maintainer_email': All(empty_none, Any(All(str, email), None)),
     'state': Any(str, None),
-}], required=True, extra=True)
+}, required=True, extra=True)


### PR DESCRIPTION
This prevents showing the name of the remote dataset instead of the id when the validation fails for this dataset. It also prevents the dataset from being archived when it already exists.

I did not find any testing tooling for generating semi-valid payload from CKAN so I did not add any test.

<img width="787" alt="Capture d’écran 2023-01-03 à 17 25 53" src="https://user-images.githubusercontent.com/119625/210398760-e4db38a6-1c7b-42dd-8c89-cdb18bc98b2f.png">

Fix https://github.com/etalab/data.gouv.fr/issues/1014
