### PR TITLE
Refactor tests using mocks instead of a real CKAN catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,29 +7,6 @@ jobs:
       - image: udata/circleci:2-alpine
       - image: mongo:3.6
       - image: redis:alpine
-      - image: udata/elasticsearch:2.4.5
-      - image: postgres:11-alpine
-        name: db
-        environment:
-          POSTGRES_DB: ckan
-          POSTGRES_USER: ckan
-          POSTGRES_PASSWORD: ckan
-          DS_RO_PASS: datastore
-      - image: ckan/solr:latest
-        name: solr
-      - image: udata/ckan-test
-        environment:
-          CKAN_SQLALCHEMY_URL: postgresql://ckan:ckan@db/ckan
-          CKAN_DATASTORE_WRITE_URL: postgresql://ckan:ckan@db/datastore
-          CKAN_DATASTORE_READ_URL: postgresql://datastore_ro:datastore@db/datastore
-          CKAN_SOLR_URL: http://solr:8983/solr/ckan
-          CKAN_REDIS_URL: redis://localhost:6379/1
-          CKAN_DATAPUSHER_URL: http://datapusher:8800
-          CKAN_SITE_URL: http://localhost:5000
-          CKAN_MAX_UPLOAD_SIZE_MB: 50
-          CKAN_WAIT_FOR: tcp://db:5432
-          POSTGRES_PASSWORD: ckan
-          DS_RO_PASS: datastore
     environment:
        BASH_ENV: /root/.bashrc
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,11 @@ jobs:
           - py-cache-v6-{{ arch }}-{{ .Environment.BASE_BRANCH }}
       - run:
           name: Install python dependencies
+          # FIXME: For now, we fix setuptools due to https://github.com/etalab/data.gouv.fr/issues/1041
           command: |
             virtualenv venv
             source venv/bin/activate
+            pip install setuptools==66.1.1
             pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Use id as remote_id ASAP for better error handling [#239](https://github.com/opendatateam/udata-ckan/pull/239)
+- Refactor tests to mock CKAN results instead of starting a CKAN instance [#245](https://github.com/opendatateam/udata-ckan/pull/245)
 
 ## 3.0.0 (2022-11-14)
 

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,5 +1,5 @@
 mock==3.0.5
-pytest==4.6.3
-pytest-flask==0.15.0
-pytest-sugar==0.9.2
+pytest==7.2.1
+pytest-flask==1.2.0
+pytest-sugar==0.9.6
 requests-mock==1.7.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import json
 import pytest
-import re
 import requests
 
 from urllib.parse import urljoin
@@ -9,12 +8,10 @@ from faker.providers import BaseProvider
 from udata.utils import faker_provider, faker
 
 CKAN_URL = 'http://localhost:5000'
-CKAN_WAIT_TIMEOUT = 120  # Max time to wait for CKAN being ready (in seconds)
 
 
 class CkanError(ValueError):
     pass
-
 
 
 class CkanClient(object):
@@ -56,6 +53,7 @@ class CkanClient(object):
 @pytest.fixture(scope='session')
 def ckan():
     return CkanClient()
+
 
 @faker_provider
 class UdataCkanProvider(BaseProvider):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ class CkanClient(object):
     def headers(self):
         return {
             'Content-Type': 'application/json',
-            'Authorization': self.apikey,
+            'Authorization': 'dummy_apikey',
         }
 
     def get(self, url, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ class CkanClient(object):
     BASE_URL = CKAN_URL
     API_URL = '{}/api/3/action/'.format(BASE_URL)
     PACKAGE_LIST_URL = '{}package_list'.format(API_URL)
+    PACKAGE_SEARCH_URL = '{}package_search'.format(API_URL)
     PACKAGE_SHOW_URL = '{}package_show'.format(API_URL)
 
     @property

--- a/tests/test_ckan_backend.py
+++ b/tests/test_ckan_backend.py
@@ -64,7 +64,7 @@ def ckan_package(data):
         res['resource_type'] = res.get('resource_type', 'file')
         res['created'] = res.get('created', faker.date())
         res['last_modified'] = res.get('last_modified', faker.date())
-    
+
     return {'success': True, 'result': result_data}
 
 
@@ -81,9 +81,9 @@ def harvest_ckan(request, source, ckan, app, rmock):
     result = ckan_package(data)
 
     rmock.get(ckan.PACKAGE_SHOW_URL, json=result, status_code=200,
-            headers={'Content-Type': 'application/json'})
-    rmock.get(ckan.PACKAGE_LIST_URL, json={'success': True, 'result': [result['result']['id']]}, status_code=200,
-            headers={'Content-Type': 'application/json'})
+              headers={'Content-Type': 'application/json'})
+    rmock.get(ckan.PACKAGE_LIST_URL, json={'success': True, 'result': [result['result']['id']]},
+              status_code=200, headers={'Content-Type': 'application/json'})
 
     with app.app_context():
         actions.run(source.slug)

--- a/tests/test_ckan_backend.py
+++ b/tests/test_ckan_backend.py
@@ -17,21 +17,7 @@ class CkanSettings(Testing):
     PLUGINS = ['ckan']
 
 
-##############################################################################
-#                              Module fixtures                               #
-#                                                                            #
-# This module behave like a single CKAN harvest run.                         #
-# CKAN and udata DB are instanciated once for the whole module to speedup    #
-# tests.                                                                     #
-##############################################################################
-
-@pytest.fixture(scope='module')
-def ckan(ckan_factory):
-    '''Instanciate a clean CKAN instance once for this module. '''
-    return ckan_factory()
-
-
-@pytest.fixture(scope='module')
+@pytest.fixture()
 def app(request):
     '''Create an udata app once for the module. '''
     app = create_app(Defaults, override=CkanSettings)
@@ -42,11 +28,11 @@ def app(request):
         drop_db(app)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture()
 def source(app, ckan):
     '''
     Create an harvest source for an organization.
-    The source is ctreated once for the module.
+    The source is created once for the module.
     '''
     with app.app_context():
         org = OrganizationFactory()
@@ -55,61 +41,78 @@ def source(app, ckan):
                                     organization=org)
 
 
-@pytest.fixture(scope='module', autouse=True)
-def feed_ckan_and_harvest(request, source, ckan, app):
-    '''
-    This fixture feed CKAN with data from data fixtures,
-    then perform the harvesting and return the data and
-    results for this module tests
-    '''
-    module = request.module
-    session = request.session
-    items = [item for item in session.items if item.module == module]
-    rundata = {}
-
-    fixtures = {
-        i.get_closest_marker('ckan_data').args[0]
-        for i in items if i.get_closest_marker('ckan_data')
+def ckan_package(data):
+    result_data = {
+        'id': faker.uuid4(),
+        'metadata_modified': faker.date(),
+        'tags': [],
+        'license_id': None,
+        'metadata_created': faker.date(),
+        'type': 'dataset',
+        'author': None,
+        'maintainer_email': None,
+        'state': None,
+        'author_email': None,
+        'license_title': None,
+        'organization': None,
+        'private': False,
+        'maintainer': None
     }
+    result_data.update(data)
 
-    for fixture in fixtures:
-        values = request.getfixturevalue(fixture)
-        data, kwargs = values if isinstance(values, tuple) else (values, {})
-        result = ckan.action('package_create', data)
-        rundata[fixture] = data, result, kwargs
+    for res in result_data.get('resources', []):
+        res['id'] = faker.uuid4()
+        res['resource_type'] = res.get('resource_type', 'file')
+        res['created'] = res.get('created', faker.date())
+        res['last_modified'] = res.get('last_modified', faker.date())
+    
+    return {'success': True, 'result': result_data}
+
+
+@pytest.fixture(scope='function')
+def harvest_ckan(request, source, ckan, app, rmock):
+    '''
+    This fixture performs the harvesting and return the data, result
+    and kwargs for this test case
+    '''
+
+    fixture = request.node.get_closest_marker('ckan_data').args[0]
+    values = request.getfixturevalue(fixture)
+    data, kwargs = values if isinstance(values, tuple) else (values, {})
+    result = ckan_package(data)
+
+    rmock.get(ckan.PACKAGE_SHOW_URL, json=result, status_code=200,
+            headers={'Content-Type': 'application/json'})
+    rmock.get(ckan.PACKAGE_LIST_URL, json={'success': True, 'result': [result['result']['id']]}, status_code=200,
+            headers={'Content-Type': 'application/json'})
 
     with app.app_context():
         actions.run(source.slug)
         source.reload()
         job = source.get_last_job()
-        assert len(job.items) == len(fixtures)
+        assert len(job.items) == 1
 
-    return rundata
+    return data, result, kwargs
 
 
 ##############################################################################
 #                       Method fixtures and helpers                          #
 ##############################################################################
 
-@pytest.fixture
-def data_name(request):
-    marker = request.node.get_closest_marker('ckan_data')
-    return marker.args[0]
-
 
 @pytest.fixture
-def data(feed_ckan_and_harvest, data_name):
-    return feed_ckan_and_harvest[data_name][0]
+def data(harvest_ckan):
+    return harvest_ckan[0]
 
 
 @pytest.fixture
-def result(feed_ckan_and_harvest, data_name):
-    return feed_ckan_and_harvest[data_name][1]
+def result(harvest_ckan):
+    return harvest_ckan[1]
 
 
 @pytest.fixture
-def kwargs(feed_ckan_and_harvest, data_name):
-    return feed_ckan_and_harvest[data_name][2]
+def kwargs(harvest_ckan):
+    return harvest_ckan[2]
 
 
 def job_item_for(job, result):
@@ -130,7 +133,7 @@ def dataset_for(result):
 # The 2nd argument can ben whatever needs to be given to the test function   #
 ##############################################################################
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def minimal():
     resource_url = faker.unique_url()
     data = {
@@ -142,7 +145,7 @@ def minimal():
     return data, {'resource_url': resource_url}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def all_metadata():
     resource_data = {
         'name': faker.sentence(),
@@ -163,7 +166,7 @@ def all_metadata():
     return data, {'resource_data': resource_data}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def spatial_geom_polygon():
     polygon = faker.polygon()
     data = {
@@ -176,7 +179,7 @@ def spatial_geom_polygon():
     return data, {'polygon': polygon}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def spatial_geom_multipolygon():
     multipolygon = faker.multipolygon()
     data = {
@@ -189,7 +192,7 @@ def spatial_geom_multipolygon():
     return data, {'multipolygon': multipolygon}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def known_spatial_text_name(app):
     with app.app_context():
         zone = GeoZoneFactory(validity=None)
@@ -203,7 +206,7 @@ def known_spatial_text_name(app):
     return data, {'zone': zone}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def known_spatial_text_slug(app):
     with app.app_context():
         zone = GeoZoneFactory(validity=None)
@@ -217,7 +220,7 @@ def known_spatial_text_slug(app):
     return data, {'zone': zone}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def multiple_known_spatial_text(app):
     name = faker.word()
     with app.app_context():
@@ -232,7 +235,7 @@ def multiple_known_spatial_text(app):
     return data, {'name': name}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def unknown_spatial_text():
     spatial = 'Somewhere'
     data = {
@@ -245,7 +248,7 @@ def unknown_spatial_text():
     return data, {'spatial': spatial}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def spatial_uri():
     spatial = 'http://www.geonames.org/2111964'
     data = {
@@ -258,17 +261,18 @@ def spatial_uri():
     return data, {'spatial': spatial}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def skipped_no_resources():
     return {
         'name': faker.unique_string(),
         'title': faker.sentence(),
         'notes': faker.paragraph(),
         'tags': [{'name': faker.unique_string()} for _ in range(3)],
+        'resources': []
     }
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def ckan_url_is_url():
     url = faker.unique_url()
     data = {
@@ -281,7 +285,7 @@ def ckan_url_is_url():
     return data, {'url': url}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def ckan_url_is_a_string():
     url = faker.sentence()
     data = {
@@ -294,7 +298,7 @@ def ckan_url_is_a_string():
     return data, {'url': url}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def frequency_as_rdf_uri():
     data = {
         'name': faker.unique_string(),
@@ -308,7 +312,7 @@ def frequency_as_rdf_uri():
     return data, {'expected': 'daily'}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def frequency_as_exact_match():
     data = {
         'name': faker.unique_string(),
@@ -320,7 +324,7 @@ def frequency_as_exact_match():
     return data, {'expected': 'daily'}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def frequency_as_unknown_value():
     value = 'unkowwn-value'
     data = {
@@ -333,7 +337,7 @@ def frequency_as_unknown_value():
     return data, {'expected': value}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def empty_extras():
     return {
         'name': faker.unique_string(),
@@ -421,7 +425,6 @@ def test_geospatial_geom_multipolygon(result, kwargs):
 def test_skip_no_resources(source, result):
     job = source.get_last_job()
     item = job_item_for(job, result)
-
     assert item.status == 'skipped'
     assert dataset_for(result) is None
 
@@ -510,7 +513,7 @@ def test_keep_unknown_spatial_uri_as_extra(result, kwargs):
 ##############################################################################
 #                       Edge cases manually written                          #
 ##############################################################################
-def test_minimal_ckan_response(rmock):
+def test_minimal_ckan_response(app, rmock):
     '''CKAN Harvester should accept the minimum dataset payload'''
     CKAN_URL = 'https://harvest.me/'
     API_URL = '{}api/3/action/'.format(CKAN_URL)
@@ -553,7 +556,7 @@ def test_minimal_ckan_response(rmock):
     assert source.get_last_job().status == 'done'
 
 
-def test_flawed_ckan_response(rmock):
+def test_flawed_ckan_response(app, rmock):
     '''CKAN Harvester should report item error with id == remote_id in item'''
     CKAN_URL = 'https://harvest.me/'
     API_URL = '{}api/3/action/'.format(CKAN_URL)

--- a/tests/test_ckan_backend.py
+++ b/tests/test_ckan_backend.py
@@ -17,9 +17,9 @@ class CkanSettings(Testing):
     PLUGINS = ['ckan']
 
 
-@pytest.fixture()
+@pytest.fixture
 def app(request):
-    '''Create an udata app once for the module. '''
+    '''Create an udata app. '''
     app = create_app(Defaults, override=CkanSettings)
     with app.app_context():
         drop_db(app)
@@ -28,11 +28,10 @@ def app(request):
         drop_db(app)
 
 
-@pytest.fixture()
+@pytest.fixture
 def source(app, ckan):
     '''
     Create an harvest source for an organization.
-    The source is created once for the module.
     '''
     with app.app_context():
         org = OrganizationFactory()
@@ -69,7 +68,7 @@ def ckan_package(data):
     return {'success': True, 'result': result_data}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def harvest_ckan(request, source, ckan, app, rmock):
     '''
     This fixture performs the harvesting and return the data, result
@@ -133,7 +132,7 @@ def dataset_for(result):
 # The 2nd argument can ben whatever needs to be given to the test function   #
 ##############################################################################
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def minimal():
     resource_url = faker.unique_url()
     data = {
@@ -145,7 +144,7 @@ def minimal():
     return data, {'resource_url': resource_url}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def all_metadata():
     resource_data = {
         'name': faker.sentence(),
@@ -166,7 +165,7 @@ def all_metadata():
     return data, {'resource_data': resource_data}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def spatial_geom_polygon():
     polygon = faker.polygon()
     data = {
@@ -179,7 +178,7 @@ def spatial_geom_polygon():
     return data, {'polygon': polygon}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def spatial_geom_multipolygon():
     multipolygon = faker.multipolygon()
     data = {
@@ -192,7 +191,7 @@ def spatial_geom_multipolygon():
     return data, {'multipolygon': multipolygon}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def known_spatial_text_name(app):
     with app.app_context():
         zone = GeoZoneFactory(validity=None)
@@ -206,7 +205,7 @@ def known_spatial_text_name(app):
     return data, {'zone': zone}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def known_spatial_text_slug(app):
     with app.app_context():
         zone = GeoZoneFactory(validity=None)
@@ -220,7 +219,7 @@ def known_spatial_text_slug(app):
     return data, {'zone': zone}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def multiple_known_spatial_text(app):
     name = faker.word()
     with app.app_context():
@@ -235,7 +234,7 @@ def multiple_known_spatial_text(app):
     return data, {'name': name}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def unknown_spatial_text():
     spatial = 'Somewhere'
     data = {
@@ -248,7 +247,7 @@ def unknown_spatial_text():
     return data, {'spatial': spatial}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def spatial_uri():
     spatial = 'http://www.geonames.org/2111964'
     data = {
@@ -261,7 +260,7 @@ def spatial_uri():
     return data, {'spatial': spatial}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def skipped_no_resources():
     return {
         'name': faker.unique_string(),
@@ -272,7 +271,7 @@ def skipped_no_resources():
     }
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def ckan_url_is_url():
     url = faker.unique_url()
     data = {
@@ -285,7 +284,7 @@ def ckan_url_is_url():
     return data, {'url': url}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def ckan_url_is_a_string():
     url = faker.sentence()
     data = {
@@ -298,7 +297,7 @@ def ckan_url_is_a_string():
     return data, {'url': url}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def frequency_as_rdf_uri():
     data = {
         'name': faker.unique_string(),
@@ -312,7 +311,7 @@ def frequency_as_rdf_uri():
     return data, {'expected': 'daily'}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def frequency_as_exact_match():
     data = {
         'name': faker.unique_string(),
@@ -324,7 +323,7 @@ def frequency_as_exact_match():
     return data, {'expected': 'daily'}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def frequency_as_unknown_value():
     value = 'unkowwn-value'
     data = {
@@ -337,7 +336,7 @@ def frequency_as_unknown_value():
     return data, {'expected': value}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def empty_extras():
     return {
         'name': faker.unique_string(),

--- a/tests/test_ckan_backend_filters.py
+++ b/tests/test_ckan_backend_filters.py
@@ -3,7 +3,6 @@ import urllib
 
 from udata.harvest import actions
 from udata.harvest.tests.factories import HarvestSourceFactory
-from udata.models import Dataset
 from udata.utils import faker
 
 
@@ -18,8 +17,8 @@ def test_include_org_filter(ckan, rmock):
         'filters': [{'key': 'organization', 'value': 'organization_name'}]
     })
 
-    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}}, status_code=200,
-        headers={'Content-Type': 'application/json'})
+    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}},
+              status_code=200, headers={'Content-Type': 'application/json'})
 
     actions.run(source.slug)
     source.reload()
@@ -31,13 +30,14 @@ def test_include_org_filter(ckan, rmock):
     }
     assert rmock.last_request.url == f'{ckan.PACKAGE_SEARCH_URL}?{urllib.parse.urlencode(params)}'
 
+
 def test_exclude_org_filter(ckan, rmock):
     source = HarvestSourceFactory(backend='ckan', url=ckan.BASE_URL, config={
         'filters': [{'key': 'organization', 'value': 'organization_name', 'type': 'exclude'}]
     })
 
-    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}}, status_code=200,
-        headers={'Content-Type': 'application/json'})
+    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}},
+              status_code=200, headers={'Content-Type': 'application/json'})
 
     actions.run(source.slug)
     source.reload()
@@ -50,6 +50,7 @@ def test_exclude_org_filter(ckan, rmock):
     }
     assert rmock.last_request.url == f'{ckan.PACKAGE_SEARCH_URL}?{urllib.parse.urlencode(params)}'
 
+
 def test_tag_filter(ckan, rmock):
 
     tag = faker.word()
@@ -57,8 +58,8 @@ def test_tag_filter(ckan, rmock):
         'filters': [{'key': 'tags', 'value': tag}]
     })
 
-    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}}, status_code=200,
-        headers={'Content-Type': 'application/json'})
+    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}},
+              status_code=200, headers={'Content-Type': 'application/json'})
 
     actions.run(source.slug)
     source.reload()
@@ -77,8 +78,8 @@ def test_exclude_tag_filter(ckan, rmock):
         'filters': [{'key': 'tags', 'value': tag, 'type': 'exclude'}]
     })
 
-    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}}, status_code=200,
-        headers={'Content-Type': 'application/json'})
+    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}},
+              status_code=200, headers={'Content-Type': 'application/json'})
 
     actions.run(source.slug)
     source.reload()
@@ -99,9 +100,8 @@ def test_can_have_multiple_filters(ckan, rmock):
         ]
     })
 
-
-    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}}, status_code=200,
-        headers={'Content-Type': 'application/json'})
+    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}},
+              status_code=200, headers={'Content-Type': 'application/json'})
 
     actions.run(source.slug)
     source.reload()

--- a/tests/test_ckan_backend_filters.py
+++ b/tests/test_ckan_backend_filters.py
@@ -1,4 +1,5 @@
 import pytest
+import urllib
 
 from udata.harvest import actions
 from udata.harvest.tests.factories import HarvestSourceFactory
@@ -12,135 +13,102 @@ pytestmark = [
 ]
 
 
-@pytest.fixture
-def ckan(ckan_factory):
-    '''Instanciate a clean CKAN instance once for this module. '''
-    return ckan_factory()
+def test_include_org_filter(ckan, rmock):
+    source = HarvestSourceFactory(backend='ckan', url=ckan.BASE_URL, config={
+        'filters': [{'key': 'organization', 'value': 'organization_name'}]
+    })
 
+    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}}, status_code=200,
+        headers={'Content-Type': 'application/json'})
 
-def package_factory(ckan, **kwargs):
-    data = {
-        'name': faker.unique_string(),
-        'title': faker.sentence(),
-        'notes': faker.paragraph(),
-        'resources': [{'url': faker.unique_url()}],
+    actions.run(source.slug)
+    source.reload()
+
+    assert rmock.call_count == 1
+    params = {
+        'q': f'organization:organization_name',
+        'rows': 1000
     }
-    data.update(kwargs)
-    response = ckan.action('package_create', data)
-    return response['result']
+    assert rmock.last_request.url == f'{ckan.PACKAGE_SEARCH_URL}?{urllib.parse.urlencode(params)}'
 
-
-def test_include_org_filter(ckan):
-    # create 2 organizations with 2 datasets each
-    org = ckan.action('organization_create', {'name': 'org-1'})['result']
-    included_ids = [d['id'] for d in [
-        package_factory(ckan, owner_org=org['id']),
-        package_factory(ckan, owner_org=org['id']),
-    ]]
-    org2 = ckan.action('organization_create', {'name': 'org-2'})['result']
-    package_factory(ckan, owner_org=org2['id'])
-    package_factory(ckan, owner_org=org2['id'])
-
+def test_exclude_org_filter(ckan, rmock):
     source = HarvestSourceFactory(backend='ckan', url=ckan.BASE_URL, config={
-        'filters': [{'key': 'organization', 'value': org['name']}]
+        'filters': [{'key': 'organization', 'value': 'organization_name', 'type': 'exclude'}]
     })
+
+    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}}, status_code=200,
+        headers={'Content-Type': 'application/json'})
 
     actions.run(source.slug)
     source.reload()
 
-    job = source.get_last_job()
-    assert len(job.items) == len(included_ids)
+    assert rmock.call_count == 1
 
-    for dataset in Dataset.objects:
-        assert dataset.harvest.remote_id in included_ids
+    params = {
+        'q': f'-organization:organization_name',
+        'rows': 1000
+    }
+    assert rmock.last_request.url == f'{ckan.PACKAGE_SEARCH_URL}?{urllib.parse.urlencode(params)}'
 
+def test_tag_filter(ckan, rmock):
 
-def test_exclude_org_filter(ckan):
-    # create 2 organizations with 2 datasets each
-    org = ckan.action('organization_create', {'name': 'org-1'})['result']
-    included_ids = [d['id'] for d in [
-        package_factory(ckan, owner_org=org['id']),
-        package_factory(ckan, owner_org=org['id']),
-    ]]
-    org2 = ckan.action('organization_create', {'name': 'org-2'})['result']
-    excluded_ids = [d['id'] for d in [
-        package_factory(ckan, owner_org=org2['id']),
-        package_factory(ckan, owner_org=org2['id']),
-    ]]
-
-    source = HarvestSourceFactory(backend='ckan', url=ckan.BASE_URL, config={
-        'filters': [{'key': 'organization', 'value': org2['name'], 'type': 'exclude'}]
-    })
-
-    actions.run(source.slug)
-    source.reload()
-
-    job = source.get_last_job()
-    assert len(job.items) == len(included_ids)
-
-    for dataset in Dataset.objects:
-        assert dataset.harvest.remote_id in included_ids
-        assert dataset.harvest.remote_id not in excluded_ids
-
-
-def test_tag_filter(ckan):
-    # create 2 datasets with a different tag each
     tag = faker.word()
-    package = package_factory(ckan, tags=[{'name': tag}])
-    package_factory(ckan, tags=[{'name': faker.word()}])
-
     source = HarvestSourceFactory(backend='ckan', url=ckan.BASE_URL, config={
         'filters': [{'key': 'tags', 'value': tag}]
     })
 
+    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}}, status_code=200,
+        headers={'Content-Type': 'application/json'})
+
     actions.run(source.slug)
     source.reload()
 
-    job = source.get_last_job()
-    assert len(job.items) == 1
-    assert Dataset.objects.count() == 1
-    assert Dataset.objects.first().harvest.remote_id == package['id']
+    assert rmock.call_count == 1
+    params = {
+        'q': f'tags:{tag}',
+        'rows': 1000
+    }
+    assert rmock.last_request.url == f'{ckan.PACKAGE_SEARCH_URL}?{urllib.parse.urlencode(params)}'
 
 
-def test_exclude_tag_filter(ckan):
-    # create 2 datasets with a different tag each
+def test_exclude_tag_filter(ckan, rmock):
     tag = faker.word()
-    package_factory(ckan, tags=[{'name': tag}])
-    included = package_factory(ckan, tags=[{'name': faker.word()}])
-
     source = HarvestSourceFactory(backend='ckan', url=ckan.BASE_URL, config={
         'filters': [{'key': 'tags', 'value': tag, 'type': 'exclude'}]
     })
 
+    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}}, status_code=200,
+        headers={'Content-Type': 'application/json'})
+
     actions.run(source.slug)
     source.reload()
 
-    job = source.get_last_job()
-    assert len(job.items) == 1
-    assert Dataset.objects.count() == 1
-    assert Dataset.objects.first().harvest.remote_id == included['id']
+    assert rmock.call_count == 1
+    params = {
+        'q': f'-tags:{tag}',
+        'rows': 1000
+    }
+    assert rmock.last_request.url == f'{ckan.PACKAGE_SEARCH_URL}?{urllib.parse.urlencode(params)}'
 
 
-def test_can_have_multiple_filters(ckan):
-    # create 2 organizations with 2 datasets each
-    org = ckan.action('organization_create', {'name': 'org-1'})['result']
-    package = package_factory(ckan, owner_org=org['id'], tags=[{'name': 'tag-1'}])
-    package_factory(ckan, owner_org=org['id'], tags=[{'name': 'tag-2'}])
-    org2 = ckan.action('organization_create', {'name': 'org-2'})['result']
-    package_factory(ckan, owner_org=org2['id'], tags=[{'name': 'tag-1'}]),
-    package_factory(ckan, owner_org=org2['id'], tags=[{'name': 'tag-2'}]),
-
+def test_can_have_multiple_filters(ckan, rmock):
     source = HarvestSourceFactory(backend='ckan', url=ckan.BASE_URL, config={
         'filters': [
-            {'key': 'organization', 'value': org['name']},
+            {'key': 'organization', 'value': 'organization_name'},
             {'key': 'tags', 'value': 'tag-2', 'type': 'exclude'},
         ]
     })
 
+
+    rmock.get(ckan.PACKAGE_SEARCH_URL, json={'success': True, 'result': {"results": []}}, status_code=200,
+        headers={'Content-Type': 'application/json'})
+
     actions.run(source.slug)
     source.reload()
 
-    job = source.get_last_job()
-    assert len(job.items) == 1
-    assert Dataset.objects.count() == 1
-    assert Dataset.objects.first().harvest.remote_id == package['id']
+    assert rmock.call_count == 1
+    params = {
+        'q': f'organization:organization_name AND -tags:tag-2',
+        'rows': 1000
+    }
+    assert rmock.last_request.url == f'{ckan.PACKAGE_SEARCH_URL}?{urllib.parse.urlencode(params)}'

--- a/udata_ckan/harvesters.py
+++ b/udata_ckan/harvesters.py
@@ -266,6 +266,7 @@ class CkanBackend(BaseBackend):
             resource.hash = res.get('hash')
             resource.harvest.created_at = res['created']
             resource.harvest.modified_at = res['last_modified']
+            resource.published = resource.published or resource.created
 
         return dataset
 

--- a/udata_ckan/harvesters.py
+++ b/udata_ckan/harvesters.py
@@ -266,7 +266,6 @@ class CkanBackend(BaseBackend):
             resource.hash = res.get('hash')
             resource.harvest.created_at = res['created']
             resource.harvest.modified_at = res['last_modified']
-            resource.published = resource.published or resource.created
 
         return dataset
 


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/1065

Instead of using more recent images for CKAN as well as a custom udata/ckan image, we suggest to mock results returned by CKAN directly.
Indeed, starting CKAN catalogs seem overkill and harder to maintain, just for tests on its exposition.

When testing filters, we only make sure the correct url are built based on filters.

Target is #243. The `published` and `created` error should be fixed there.