### PR TITLE
Raise exception on HTTP errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Raise exception on HTTP errors [#252](https://github.com/opendatateam/udata-ckan/pull/252)
 
 ## 4.0.0 (2024-06-07)
 

--- a/udata_ckan/harvesters.py
+++ b/udata_ckan/harvesters.py
@@ -63,12 +63,13 @@ class CkanBackend(BaseBackend):
         else:
             response = self.get(url, params=kwargs)
 
+        response.raise_for_status()
         content_type = response.headers.get('Content-Type', '')
         mime_type = content_type.split(';', 1)[0]
 
         if mime_type == 'application/json':  # Standard API JSON response
             data = response.json()
-            # CKAN API always returns 200 even on errors
+            # CKAN API can returns 200 even on errors
             # Only the `success` property allows to detect errors
             if data.get('success', False):
                 return data


### PR DESCRIPTION
[This error](https://errors.data.gouv.fr/organizations/sentry/issues/141771/) seems to be related to a 500 in CKAN API. We should raise on status even if CKAN API uses 200 for known errors.